### PR TITLE
Add primitive_types support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "indexmap 2.0.2",
  "ipnetwork",
  "pretty_assertions",
+ "primitive-types",
  "rust_decimal",
  "semver",
  "serde",
@@ -95,6 +96,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +115,12 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "darling"
@@ -189,6 +202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +242,12 @@ name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "ident_case"
@@ -333,6 +361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +524,18 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
+]
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
 ]
 
 [[package]]

--- a/schemars/Cargo.toml
+++ b/schemars/Cargo.toml
@@ -35,6 +35,7 @@ bigdecimal04 = { version = "0.4", default-features = false, optional = true, pac
 enumset = { version = "1.0", optional = true }
 smol_str = { version = "0.1.17", optional = true }
 semver = { version = "1.0.9", features = ["serde"], optional = true }
+primitive-types = { version = "0.12.2", default-features = false, optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
@@ -63,6 +64,8 @@ indexmap1 = ["indexmap"]
 raw_value = ["serde_json/raw_value"]
 # `bigdecimal` feature without version suffix is included only for back-compat - will be removed in a later version
 bigdecimal = ["bigdecimal03"]
+
+primitive_types = ["primitive-types"]
 
 ui_test = []
 

--- a/schemars/src/json_schema_impls/mod.rs
+++ b/schemars/src/json_schema_impls/mod.rs
@@ -72,6 +72,8 @@ mod maps;
 mod nonzero_signed;
 mod nonzero_unsigned;
 mod primitives;
+#[cfg(feature = "primitive_types")]
+mod primitive_types;
 #[cfg(feature = "semver")]
 mod semver;
 mod sequences;

--- a/schemars/src/json_schema_impls/primitive_types.rs
+++ b/schemars/src/json_schema_impls/primitive_types.rs
@@ -1,0 +1,80 @@
+use primitive_types::H128;
+use primitive_types::H160;
+use primitive_types::H256;
+use primitive_types::H384;
+use primitive_types::H512;
+use primitive_types::H768;
+use primitive_types::U128;
+use primitive_types::U256;
+use primitive_types::U512;
+
+use crate::gen::SchemaGenerator;
+use crate::schema::*;
+use crate::JsonSchema;
+use std::borrow::Cow;
+
+macro_rules! schema_uint {
+    ($t:ty) => {
+        impl JsonSchema for $t {
+            no_ref_schema!();
+        
+            fn schema_name() -> String {
+                stringify!($t).to_string()
+            }
+        
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed(std::any::type_name::<$t>())
+            }
+        
+            fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    ..Default::default()
+                }
+                .into()
+            }
+        }
+    };
+}
+
+macro_rules! schema_fixed_hash {
+    ($t:ty,$len_in_chars:literal) => {
+        impl JsonSchema for $t {
+            no_ref_schema!();
+
+            fn schema_name() -> String {
+                stringify!($t).to_string()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                Cow::Borrowed(std::any::type_name::<$t>())
+            }
+
+            fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    string: Some(Box::new(StringValidation {
+                        pattern: Some(concat!("0x\\w{", stringify!($len_in_chars),"}").to_string()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                }
+                .into()
+            }
+        }
+    };
+}
+
+schema_uint!(U128);
+schema_uint!(U256);
+schema_uint!(U512);
+
+schema_fixed_hash!(H128, 32);
+schema_fixed_hash!(H160, 40);
+schema_fixed_hash!(H256, 64);
+schema_fixed_hash!(H384, 96);
+schema_fixed_hash!(H512, 128);
+schema_fixed_hash!(H768, 192);
+
+
+

--- a/schemars/tests/expected/h160.json
+++ b/schemars/tests/expected/h160.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "H160",
+  "type": "string",
+  "pattern": "0x\\w{40}"
+}

--- a/schemars/tests/expected/u256.json
+++ b/schemars/tests/expected/u256.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "U256",
+  "type": "string"
+}

--- a/schemars/tests/primitive_types.rs
+++ b/schemars/tests/primitive_types.rs
@@ -1,0 +1,12 @@
+mod util;
+use util::*;
+
+#[test]
+fn u256() -> TestResult {
+    test_default_generated_schema::<primitive_types::U256>("u256")
+}
+
+#[test]
+fn h160() -> TestResult {
+    test_default_generated_schema::<primitive_types::H160>("h160")
+}


### PR DESCRIPTION
This commit adds support for the `primitive_types` - an extremely popular long math arithmetic crate.